### PR TITLE
Copying down postgresql governor

### DIFF
--- a/init-container.py
+++ b/init-container.py
@@ -1100,7 +1100,7 @@ def delete_files(config):
     # Copy files.
 
     for file in files:
-        if  os.path.exists(file):
+        if os.path.exists(file):
             logging.info(message_info(155, file))
             os.remove(file)
 
@@ -1335,6 +1335,7 @@ def database_initialization_postgresql(config, parsed_database_url):
                 logging.warning(message_warning(301, governor_url, err))
         else:
             logging.info(message_info(181))
+
 
 def database_initialization(config):
     ''' Given a canonical database URL, transform to the specific URL. '''

--- a/init-container.py
+++ b/init-container.py
@@ -346,6 +346,7 @@ message_dictionary = {
     "298": "Exit {0}",
     "299": "{0}",
     "300": "senzing-" + SENZING_PRODUCT_ID + "{0:04d}W",
+    "301": "Could not download the senzing postgresql governor from {0}. Ignore this on air gapped systems. Exception details: {1}",
     "499": "{0}",
     "500": "senzing-" + SENZING_PRODUCT_ID + "{0:04d}E",
     "510": "{0} - File is missing.",
@@ -1321,14 +1322,17 @@ def database_initialization_postgresql(config, parsed_database_url):
             logging.info(message_info(161, backup_odbcinst_filename, output_odbcinst_filename))
 
     # If postgres, enable the postgres governor if one does not already exist.
-    if parsed_database_url['scheme'] == 'postgresql':        
+    if parsed_database_url['scheme'] == 'postgresql':
         if not os.path.exists("/opt/senzing/g2/python/senzing_governor.py"):
             governor_url = 'https://raw.githubusercontent.com/Senzing/governor-postgresql-transaction-id/master/senzing_governor.py'
             governor_destination = '/opt/senzing/g2/python/senzing_governor.py'
             logging.info(message_info(180, governor_url, governor_destination))
-            urllib.request.urlretrieve(
-                governor_url,
-                governor_destination)
+            try:
+                urllib.request.urlretrieve(
+                    governor_url,
+                    governor_destination)
+            except urllib.error.URLError as err:
+                logging.warning(message_warning(301, governor_url, err))
         else:
             logging.info(message_info(181))
 

--- a/init-container.py
+++ b/init-container.py
@@ -20,6 +20,7 @@ import stat
 import string
 import sys
 import time
+import urllib
 
 try:
     from G2Config import G2Config
@@ -334,6 +335,8 @@ message_dictionary = {
     "162": "{0} - Creating directory",
     "170": "Created new default config in SYS_CFG having ID {0}",
     "171": "Default config in SYS_CFG already exists having ID {0}",
+    "180": "Postgresql detected, installing default governor from {0} to {1}",
+    "181": "Postgresql detected but using existing governor",
     "292": "Configuration change detected.  Old: {0} New: {1}",
     "293": "For information on warnings and errors, see https://github.com/Senzing/stream-loader#errors",
     "294": "Version: {0}  Updated: {1}",
@@ -1317,6 +1320,17 @@ def database_initialization_postgresql(config, parsed_database_url):
         else:
             logging.info(message_info(161, backup_odbcinst_filename, output_odbcinst_filename))
 
+    # If postgres, enable the postgres governor if one does not already exist.
+    if parsed_database_url['scheme'] == 'postgresql':        
+        if not os.path.exists("/opt/senzing/g2/python/senzing_governor.py"):
+            governor_url = 'https://raw.githubusercontent.com/Senzing/governor-postgresql-transaction-id/master/senzing_governor.py'
+            governor_destination = '/opt/senzing/g2/python/senzing_governor.py'
+            logging.info(message_info(180, governor_url, governor_destination))
+            urllib.request.urlretrieve(
+                governor_url,
+                governor_destination)
+        else:
+            logging.info(message_info(181))
 
 def database_initialization(config):
     ''' Given a canonical database URL, transform to the specific URL. '''


### PR DESCRIPTION
if it is postgres and there is not already one there.

## Which issue does this address

Issue number: #77 

## Why was change needed

Postgresql needs the governor for good performance.

## What does change improve

Automatically copies down the postgresql governor from https://raw.githubusercontent.com/Senzing/governor-postgresql-transaction-id/master/senzing_governor.py if the database connection string indicates postgresql and there is not already a governor at /opt/senzing/g2/python/senzing_governor.py
